### PR TITLE
Fix pytables install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 traits
 pandas
-pytables
+tables
 docopt
 nose


### PR DESCRIPTION
In pip you have to install tables and not pytables. This fixes that.
