### PR TITLE
FIX: Reindex multiple dataframes when concatenating

### DIFF
--- a/pysemantic/project.py
+++ b/pysemantic/project.py
@@ -552,7 +552,8 @@ class Project(object):
                 df_validator = DataFrameValidator(data=_df,
                                                   column_rules=column_rules)
                 dfs.append(df_validator.clean())
-            return pd.concat(dfs, axis=0)
+            df = pd.concat(dfs, axis=0)
+            return df.set_index(np.arange(df.shape[0]))
 
     def load_datasets(self):
         """Load and return all datasets.

--- a/pysemantic/tests/test_project.py
+++ b/pysemantic/tests/test_project.py
@@ -472,6 +472,7 @@ class TestProjectClass(BaseProjectTestCase):
                self.expected_specs['multi_iris']]
         dframes = [x.drop_duplicates() for x in dframes]
         dframe = pd.concat(dframes)
+        dframe.set_index(np.arange(dframe.shape[0]), inplace=True)
         self.assertDataFrameEqual(loaded['multi_iris'], dframe)
 
     def test_dataset_colnames(self):


### PR DESCRIPTION
Closes motherbox/pysemantic#32
