### PR TITLE
Safely ingnore the type of rows marked as floats but contain strings

### DIFF
--- a/pysemantic/tests/test_base.py
+++ b/pysemantic/tests/test_base.py
@@ -180,6 +180,7 @@ class BaseProjectTestCase(BaseTestCase):
                                             'Sepal Length': float,
                                             'Species': str},
                       'nrows': 150,
+                      'error_bad_lines': False,
                       'filepath_or_buffer': op.join(
                                               op.abspath(op.dirname(__file__)),
                                               "testdata", "iris.csv")}
@@ -194,11 +195,13 @@ class BaseProjectTestCase(BaseTestCase):
                                                         'y': float, 'z': float,
                                                         },
                                  'parse_dates': ['date'], 'nrows': 100,
+                                 'error_bad_lines': False,
                                  'filepath_or_buffer': op.join(
                                               op.abspath(op.dirname(__file__)),
                                               "testdata",
                                               "person_activity.tsv")}
         random_row_iris_specs = {'nrows': {'random': True, 'count': 50},
+                                 'error_bad_lines': False,
                                  'filepath_or_buffer': op.join(
                                               op.abspath(op.dirname(__file__)),
                                               "testdata", "iris.csv")}
@@ -274,7 +277,7 @@ def _get_iris_args():
     """Get the ideal parser arguments for the iris dataset."""
     filepath = op.join(op.dirname(__file__), "testdata", "iris.csv")
     return dict(filepath_or_buffer=op.abspath(filepath),
-                sep=",", nrows=150,
+                sep=",", nrows=150, error_bad_lines=False,
                 dtype={'Petal Length': float,
                        'Petal Width': float,
                        'Sepal Length': float,
@@ -286,6 +289,7 @@ def _get_person_activity_args():
     """Get the ideal parser arguments for the activity dataset."""
     filepath = op.join(op.dirname(__file__), "testdata", "person_activity.tsv")
     return dict(filepath_or_buffer=op.abspath(filepath),
+                error_bad_lines=False,
                 sep="\t", nrows=100, dtype={'sequence_name': str,
                                             'tag': str,
                                             'x': float,

--- a/pysemantic/tests/test_project.py
+++ b/pysemantic/tests/test_project.py
@@ -233,7 +233,7 @@ class TestProjectClass(BaseProjectTestCase):
         """Test if the NA representations are parsed properly."""
         project = pr.Project("pysemantic")
         loaded = project.load_dataset("bad_iris")
-        self.assertItemsEqual(loaded.shape, (300, 4))
+        self.assertItemsEqual(loaded.shape, (300, 5))
 
     def test_error_bad_lines_correction(self):
         """test if the correction for bad lines works."""

--- a/pysemantic/tests/testdata/test_dictionary.yaml
+++ b/pysemantic/tests/testdata/test_dictionary.yaml
@@ -9,12 +9,14 @@ bad_iris:
   delimiter: ','
   dtypes:
     Petal Length: &id001 !!python/name:__builtin__.float 
+    Petal Width: *id001
     Sepal Length: *id001
     Sepal Width: *id001
     Species: &id002 !!python/name:__builtin__.str 
   path: testdata/bad_iris.csv
   use_columns:
   - Petal Length
+  - Petal Width
   - Sepal Length
   - Sepal Width
   - Species

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -456,6 +456,7 @@ class SchemaValidator(HasTraits):
                 logger.warn(msg.format(self.filepath))
                 warnings.warn(msg.format(self.filepath), UserWarning)
         args = {}
+        args['error_bad_lines'] = False
         if self._delimiter:
             args['sep'] = self._delimiter
 


### PR DESCRIPTION
Closes motherbox/pysemantic#39
