### PR TITLE
More traits cleanup

### DIFF
--- a/docs/schema_ref.rst
+++ b/docs/schema_ref.rst
@@ -236,24 +236,24 @@ the following:
     x = type(foo) # where foo is the object who's type is to be yamlized
     print yaml.dump(x)
 
-* ``combine_dt_columns`` (Optional) Columns containing Date/Time values can be combined into one column by using the following schema:
+* ``parse_dates`` (Optional) Columns containing Date/Time values can be parsed into native NumPy datetime objects. This argument can be a list, or a ditionary. If it is a dictionary of the following form: 
 
   .. code-block:: yaml
 
-    combine_dt_columns:
+    parse_dates:
       output_col_name:
         - col_a
         - col_b
 
-This will parse columns ``col_a`` and ``col_b`` as datetime columns, and put the result in a column named ``output_col_name``. Specifying the output name is optional. You may declare the schema as:
+it will parse columns ``col_a`` and ``col_b`` as datetime columns, and put the result in a column named ``output_col_name``. Specifying the output name is optional. You may declare the schema as a list, as follows:
 
   .. code-block:: yaml
 
-    combine_dt_columns:
+    parse_dates:
       - col_a
       - col_b
 
-In this case the parser will simply name the output column as ``col_a_col_b``, as is the default with Pandas.
+In this case the parser will independently parse columns ``col_a`` and ``col_b`` into datetime.
 
 *NOTE*: Specifying this column will make PySemantic ignore any columns that have been declared as having the datetime type in the ``dtypes`` parameter.
 

--- a/pysemantic/project.py
+++ b/pysemantic/project.py
@@ -552,6 +552,8 @@ class Project(object):
         df_rules.update(validator.df_rules)
         logger.info("Attempting to load dataset {} with args:".format(
                                                                  dataset_name))
+        if validator.is_spreadsheet:
+            parser_args.pop('usecols', None)
         logger.info(json.dumps(parser_args, cls=TypeEncoder))
         if isinstance(parser_args, dict):
             df = self._load(parser_args)

--- a/pysemantic/tests/test_project.py
+++ b/pysemantic/tests/test_project.py
@@ -684,10 +684,10 @@ class TestProjectClass(BaseProjectTestCase):
 
     def test_dataset_colnames(self):
         """Check if the column names read by the Loader are correct."""
-        for name in ['iris', 'person_activity']:
+        for name, sep in {'iris': ',', 'person_activity': '\t'}.iteritems():
             loaded = self.project.load_dataset(name)
             columns = loaded.columns.tolist()
-            spec_colnames = self.data_specs[name]['dtypes'].keys()
+            spec_colnames = colnames(self.data_specs[name]['path'], sep=sep)
             self.assertItemsEqual(spec_colnames, columns)
 
     def test_dataset_coltypes(self):
@@ -699,8 +699,7 @@ class TestProjectClass(BaseProjectTestCase):
                     self.assertEqual(self.data_specs[name]['dtypes'][colname],
                                      str)
                 elif loaded[colname].dtype == np.dtype('<M8[ns]'):
-                    self.assertEqual(self.data_specs[name]['dtypes'][colname],
-                                     datetime.date)
+                    self.assertIn(colname, self.data_specs[name]['parse_dates'])
                 else:
                     self.assertEqual(loaded[colname].dtype,
                                      self.data_specs[name]['dtypes'][colname])

--- a/pysemantic/tests/test_validator.py
+++ b/pysemantic/tests/test_validator.py
@@ -191,7 +191,7 @@ class TestSchemaValidator(BaseTestCase):
         data = pd.DataFrame({'Date': date, 'Time': time,
                              'X': np.random.rand(len(date),)})
         data.to_csv(outpath, index=False)
-        specs = dict(path=outpath, combine_dt_columns=['Date', 'Time'])
+        specs = dict(path=outpath, parse_dates={'Date_Time': ['Date', 'Time']})
         validator = SchemaValidator(specification=specs)
         try:
             loaded = pd.read_csv(**validator.get_parser_args())

--- a/pysemantic/tests/testdata/test_dictionary.yaml
+++ b/pysemantic/tests/testdata/test_dictionary.yaml
@@ -72,13 +72,14 @@ person_activity:
   delimiter: "\t"
   dtypes:
     activity: *id002
-    date: !!python/name:datetime.date 
     sequence_name: *id002
     tag: *id002
     x: *id001
     y: *id001
     z: *id001
   nrows: 100
+  parse_dates:
+  - date
   path: testdata/person_activity.tsv
 random_row_iris:
   column_rules:

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -464,6 +464,16 @@ class SchemaValidator(HasTraits):
         logger.info(json.dumps(specs, cls=TypeEncoder))
         return True
 
+    def _check_md5(self):
+        if self.md5:
+            if self.md5 != get_md5_checksum(self.filepath):
+                msg = \
+                    """The MD5 checksum of the file {} does not match the one
+                     specified in the schema. This may not be the file you are
+                     looking for."""
+                logger.warn(msg.format(self.filepath))
+                warnings.warn(msg.format(self.filepath), UserWarning)
+
     # Property getters and setters
 
     @cached_property
@@ -506,14 +516,7 @@ class SchemaValidator(HasTraits):
 
     @cached_property
     def _get_parser_args(self):
-        if self.md5:
-            if self.md5 != get_md5_checksum(self.filepath):
-                msg = \
-                    """The MD5 checksum of the file {} does not match the one
-                     specified in the schema. This may not be the file you are
-                     looking for."""
-                logger.warn(msg.format(self.filepath))
-                warnings.warn(msg.format(self.filepath), UserWarning)
+        self._check_md5()
         args = {}
 
         for traitname, argname in TRAIT_NAME_MAP.iteritems():


### PR DESCRIPTION
- Change the schema for datetime columns. Only use a `parse_names` argument for that.
- Move the md5 check to a separate method
- Spreadsheet arguments organized separately.
- docs
