### PR TITLE
Handle invalid literal exceptions

### DIFF
--- a/pysemantic/errors.py
+++ b/pysemantic/errors.py
@@ -17,3 +17,9 @@ class MissingProject(Exception):
 class MissingConfigError(Exception):
 
     """Error raised when the pysemantic configuration file is not found."""
+
+
+class ParserArgumentError(Exception):
+
+    """Error raised when no valid parser arguments are inferred from the
+    schema."""

--- a/pysemantic/project.py
+++ b/pysemantic/project.py
@@ -24,7 +24,7 @@ from pandas.parser import CParserError
 from pandas.io.parsers import ParserWarning
 
 from pysemantic.validator import SchemaValidator, DataFrameValidator
-from pysemantic.errors import MissingProject, MissingConfigError
+from pysemantic.errors import MissingProject, MissingConfigError, ParserArgumentError
 from pysemantic.loggers import setup_logging
 from pysemantic.utils import TypeEncoder, colnames
 from pysemantic.exporters import AerospikeExporter
@@ -557,6 +557,9 @@ class Project(object):
         logger.info(json.dumps(parser_args, cls=TypeEncoder))
         if isinstance(parser_args, dict):
             df = self._load(parser_args)
+            if df is None:
+                raise ParserArgumentError("No valid parser arguments were ",
+                                          "inferred from the schema.")
             if validator.is_spreadsheet and isinstance(validator.sheetname,
                                                        list):
                 df = pd.concat(df.itervalues(), axis=0)

--- a/pysemantic/project.py
+++ b/pysemantic/project.py
@@ -558,7 +558,7 @@ class Project(object):
         if isinstance(parser_args, dict):
             df = self._load(parser_args)
             if df is None:
-                raise ParserArgumentError("No valid parser arguments were ",
+                raise ParserArgumentError("No valid parser arguments were " +
                                           "inferred from the schema.")
             if validator.is_spreadsheet and isinstance(validator.sheetname,
                                                        list):
@@ -617,6 +617,18 @@ class Project(object):
         io = parser_args.pop('io')
         return pd.read_excel(io, sheetname=sheetname, **parser_args)
 
+    def _detect_column_with_invalid_literals(self, parser_args):
+        dtypes = parser_args.pop('dtype')
+        df = self.parser(**parser_args)
+        bad_cols = []
+        for colname, dtype in dtypes.iteritems():
+            try:
+                df[colname].astype(dtype)
+            except (ValueError, TypeError):
+                bad_cols.append(colname)
+        parser_args['dtype'] = dtypes
+        return bad_cols
+
     def _load(self, parser_args):
         """The actual loader function that does the heavy lifting.
 
@@ -626,7 +638,19 @@ class Project(object):
         try:
             return self.parser(**parser_args)
         except ValueError as e:
-            if e.message.startswith("Falling back to the 'python' engine"):
+            if e.message.startswith("invalid literal"):
+                bad_cols = self._detect_column_with_invalid_literals(parser_args)
+                msg = textwrap.dedent("""\
+                        Columns {} designated as type integer could not
+                        be safely cast as integers. Attempting to load as
+                        string data. Consider changing the type in the schema.
+                        """.format(bad_cols))
+                logger.warn(msg)
+                warnings.warn(msg, ParserWarning)
+                for col in bad_cols:
+                    del parser_args['dtype'][col]
+                return self.parser(**parser_args)
+            elif e.message.startswith("Falling back to the 'python' engine"):
                 del parser_args['dtype']
                 msg = textwrap.dedent("""\
                         Dtypes are not supported regex delimiters. Ignoring the

--- a/pysemantic/tests/test_project.py
+++ b/pysemantic/tests/test_project.py
@@ -148,6 +148,24 @@ class TestProjectClass(BaseProjectTestCase):
 
     """Tests for the project class and its methods."""
 
+    def test_invalid_literals(self):
+        tempdir = tempfile.mkdtemp()
+        schema_fpath = op.join(tempdir, "schema.yml")
+        data_fpath = op.join(tempdir, "data.csv")
+        data = pd.DataFrame.from_dict(dict(col_a=range(10)))
+        data['col_b'] = ["x"] * 10
+        data.to_csv(data_fpath, index=False)
+        schema = {'dataset': {'path': data_fpath, 'dtypes': {'col_a': int,
+                                                             'col_b': int}}}
+        with open(schema_fpath, "w") as fin:
+            yaml.dump(schema, fin, Dumper=Dumper, default_flow_style=False)
+        pr.add_project("invalid_literal", schema_fpath)
+        try:
+            pr.Project("invalid_literal").load_dataset('dataset')
+        finally:
+            shutil.rmtree(tempdir)
+            pr.remove_project("invalid_literal")
+
     def test_index_col(self):
         """Test if specifying the index_col works."""
         iris_fpath = self.expected_specs['iris']['filepath_or_buffer']

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -416,10 +416,6 @@ class SchemaValidator(HasTraits):
     # Whether to raise errors on malformed lines
     error_bad_lines = Property(Bool, depends_on=['specification'])
 
-    @cached_property
-    def _get_error_bad_lines(self):
-        return self.specification.get('error_bad_lines', False)
-
     # Path to pickle file containing parser arguments
     pickle_file = Property(AbsFile, depends_on=['specification'])
 
@@ -581,6 +577,10 @@ class SchemaValidator(HasTraits):
 
     def _set_parser_args(self, specs):
         self.parser_args.update(specs)
+
+    @cached_property
+    def _get_error_bad_lines(self):
+        return self.specification.get('error_bad_lines', False)
 
     @cached_property
     def _get_pickle_file(self):


### PR DESCRIPTION
Identify columns that are wrongly designated as integer, remove them from the `dtype` argument.
