### PR TITLE
Automatically add index_col to usecols

### DIFF
--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -638,13 +638,14 @@ class SchemaValidator(HasTraits):
                 usecols = colnames(self.filepath, sep=self.delimiter)
                 for colname in self.exclude_columns:
                     usecols.remove(colname)
-            return usecols
         else:
             if usecols is None:
                 if self.filepath and not self.is_multifile:
                     return colnames(self.filepath, sep=self.delimiter)
-                return None
-            return usecols
+        if self.index_col is not None:
+            if self.index_col not in usecols:
+                usecols.append(self.index_col)
+        return usecols
 
     @cached_property
     def _get_nrows(self):


### PR DESCRIPTION
When using `index_col` and `usecols` arguments simultaneously, pandas
expects the `index_col` to be in the `usecols` list. PySemantic adds `index_col` to
`usecols` list if this is not the case.
