### PR TITLE
Use subprocess for md5 checksum verification.

### DIFF
--- a/pysemantic/utils.py
+++ b/pysemantic/utils.py
@@ -110,7 +110,6 @@ def get_md5_checksum(filepath):
     '9b3ecf3031979169c0ecc5e03cfe20a6'
 
     """
-    import hashlib
-    with open(filepath, "rb") as fid:
-        checksum = hashlib.md5(fid.read()).hexdigest()
-    return checksum
+    import subprocess
+    cmd = "md5sum {}".format(filepath).split()
+    return subprocess.check_output(cmd).rstrip().split()[0]

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -711,6 +711,12 @@ class SchemaValidator(HasTraits):
         return True
 
     def _check_md5(self):
+        import sys
+        if sys.platform != 'linux2':
+            msg = "Verifying md5 checksums is not yet supported for your OS."
+            logger.warn(msg)
+            warnings.warn(msg, UserWarning)
+            return
         if self.md5:
             if self.md5 != get_md5_checksum(self.filepath):
                 msg = \


### PR DESCRIPTION
Too slow for large files to use the old implementation
