### PR TITLE
Minor fixes

### DIFF
--- a/pysemantic/project.py
+++ b/pysemantic/project.py
@@ -465,30 +465,6 @@ class Project(object):
         specs = self.get_dataset_specs(dataset_name)
         pprint.pprint(specs)
 
-    def set_dataset_specs(self, dataset_name, specs, write_to_file=False):
-        """Sets the specifications to the dataset. Using this is not
-        recommended. All specifications for datasets should be handled through
-        the data dictionary.
-
-        :param dataset_name: Name of the dataset for which specifications \
-                need to be modified.
-        :param specs: A dictionary containing the new specifications for the \
-                dataset.
-        :param write_to_file: If true, the data dictionary will be updated to \
-                the new specifications. If False (the default), the new \
-                specifications are used for the respective dataset only for \
-                the lifetime of the `Project` object.
-        :type dataset_name: str
-        :type specs: dict
-        :type write_to_file: bool
-        :return: None
-        """
-        validator = self.validators[dataset_name]
-        logger.info("Attempting to set parser args for dataset {} to:".format(
-                                                                 dataset_name))
-        logger.info(json.dumps(specs, cls=TypeEncoder))
-        return validator.set_parser_args(specs, write_to_file)
-
     def update_dataset(self, dataset_name, dataframe, path=None, **kwargs):
         """This is tricky."""
         org_specs = self.get_dataset_specs(dataset_name)

--- a/pysemantic/tests/test_project.py
+++ b/pysemantic/tests/test_project.py
@@ -690,41 +690,6 @@ class TestProjectClass(BaseProjectTestCase):
             self.assertKwargsEqual(outargs[i],
                                    self.expected_specs['multi_iris'][i])
 
-    def test_set_dataset_specs(self):
-        """Check if setting dataset specifications through the Project object
-        works.
-        """
-        path = op.join(op.abspath(op.dirname(__file__)), "testdata",
-                       "iris.csv")
-        specs = dict(filepath_or_buffer=path,
-                     usecols=['Sepal Length', 'Petal Width', 'Species'],
-                     dtype={'Sepal Length': str})
-        self.assertTrue(self.project.set_dataset_specs("iris", specs))
-        expected = pd.read_csv(**specs)
-        loaded = self.project.load_dataset("iris")
-        self.assertDataFrameEqual(expected, loaded)
-
-    def test_set_dataset_specs_to_file(self):
-        """Check if newly set dataset specifications are written to file
-        properly."""
-        try:
-            with open(TEST_DATA_DICT, "r") as fileobj:
-                oldspecs = yaml.load(fileobj, Loader=Loader)
-            path = op.join(op.abspath(op.dirname(__file__)), "testdata",
-                           "iris.csv")
-            specs = dict(filepath_or_buffer=path,
-                         usecols=['Sepal Length', 'Petal Width', 'Species'],
-                         dtype={'Sepal Length': str})
-            self.assertTrue(self.project.set_dataset_specs("iris", specs,
-                                                           write_to_file=True))
-            with open(TEST_DATA_DICT, "r") as fileobj:
-                newspecs = yaml.load(fileobj, Loader=Loader)
-            self.assertKwargsEqual(newspecs['iris'], specs)
-        finally:
-            with open(TEST_DATA_DICT, "w") as fileobj:
-                yaml.dump(oldspecs, fileobj, Dumper=Dumper,
-                          default_flow_style=False)
-
     def test_load_all(self):
         """Test if loading all datasets in a project works as expected."""
         loaded = self.project.load_datasets()

--- a/pysemantic/tests/test_validator.py
+++ b/pysemantic/tests/test_validator.py
@@ -76,6 +76,16 @@ class TestSchemaValidator(BaseTestCase):
         # are messing up the base specifications.
         self.basespecs = deepcopy(self.specs)
 
+    def test_parse_dates_list(self):
+        """Test if arguments to `parse_dates` are put into a list."""
+        specs = deepcopy(self.basespecs['person_activity'])
+        specs['parse_dates'] = specs['parse_dates'][0]
+        validator = SchemaValidator(specification=specs)
+        parser_args = validator.get_parser_args()
+        self.assertTrue(isinstance(parser_args['parse_dates'], list))
+        df = pd.read_csv(**parser_args)
+        self.assertEqual(df['date'].dtype, np.dtype('<M8[ns]'))
+
     def test_usecols(self):
         """Test if inferring the usecols argument works."""
         specs = deepcopy(self.basespecs['iris'])

--- a/pysemantic/tests/test_validator.py
+++ b/pysemantic/tests/test_validator.py
@@ -465,27 +465,6 @@ class TestSeriesValidator(BaseTestCase):
         finally:
             del self.species_rules['postprocessors']
 
-    def test_unique_values(self):
-        """Test if the validator checks for the unique values."""
-        validator = SeriesValidator(data=self.species,
-                                    rules=self.species_rules)
-        cleaned = validator.clean()
-        self.assertItemsEqual(cleaned.unique(),
-                              self.dataframe['Species'].unique())
-
-    def test_bad_unique_values(self):
-        """Test if the validator drops values not specified in the schema."""
-        # Add some bogus values
-        noise = np.random.choice(['lily', 'petunia'], size=(50,))
-        species = np.hstack((self.species.values, noise))
-        np.random.shuffle(species)
-        species = pd.Series(species)
-
-        validator = SeriesValidator(data=species, rules=self.species_rules)
-        cleaned = validator.clean()
-        self.assertItemsEqual(cleaned.unique(),
-                              self.dataframe['Species'].unique())
-
     def test_drop_duplicates(self):
         """Check if the SeriesValidator drops duplicates in the series."""
         self.species_rules['drop_duplicates'] = True
@@ -503,7 +482,7 @@ class TestSeriesValidator(BaseTestCase):
         """Check if the SeriesValidator drops NAs in the series."""
         self.species_rules['drop_na'] = True
         try:
-            unqs = np.random.choice(self.species.unique().tolist() + [np.nan],
+            unqs = np.random.choice(self.species.unique().tolist() + [None],
                                     size=(100,))
             unqs = pd.Series(unqs)
             validator = SeriesValidator(data=unqs,
@@ -581,9 +560,34 @@ class TestDataFrameValidator(BaseTestCase):
         pa_dframe = pd.read_csv(**pa_validator.get_parser_args())
         cls.iris_dframe = iris_dframe
         cls.pa_dframe = pa_dframe
+        cls.species_rules = {'unique_values': ['setosa', 'virginica',
+                                               'versicolor'],
+                             'drop_duplicates': False, 'drop_na': False}
 
     def setUp(self):
         self.basespecs = deepcopy(self._basespecs)
+
+    def test_unique_values(self):
+        """Test if the validator checks for the unique values."""
+        validator = DataFrameValidator(data=self.iris_dframe,
+                column_rules={'Species': self.species_rules})
+        cleaned = validator.clean()
+        self.assertItemsEqual(cleaned.Species.unique(),
+                              ['setosa', 'versicolor', 'virginica'])
+
+    def test_bad_unique_values(self):
+        """Test if the validator drops values not specified in the schema."""
+        # Add some bogus values
+        noise = np.random.choice(['lily', 'petunia'], size=(50,))
+        species = np.hstack((self.iris_dframe.Species.values, noise))
+        np.random.shuffle(species)
+        species = pd.Series(species)
+
+        validator = DataFrameValidator(data=pd.DataFrame({'Species': species}),
+                                  column_rules={'Species': self.species_rules})
+        cleaned = validator.clean()
+        self.assertItemsEqual(cleaned.Species.unique(),
+                              ['setosa', 'versicolor', 'virginica'])
 
     def test_colnames_as_list(self):
         """Test if the column names option works when provided as a list."""

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -729,7 +729,11 @@ class SchemaValidator(HasTraits):
     # Property getters and setters
     @cached_property
     def _get_parse_dates(self):
-        return self.specification.get("parse_dates", False)
+        parse_dates = self.specification.get("parse_dates", False)
+        if parse_dates:
+            if isinstance(parse_dates, str):
+                parse_dates = [parse_dates]
+        return parse_dates
 
     @cached_property
     def _get_filepath(self):


### PR DESCRIPTION
- Remove setting schema from the `Project` class
- Filtering for unique values now happens in `DataFrameValidator`
- If argument to `parse_dates` is a string, convert automatically to list.
