### PR TITLE
Fix enforcement of index rules

### DIFF
--- a/pysemantic/tests/test_validator.py
+++ b/pysemantic/tests/test_validator.py
@@ -103,6 +103,7 @@ class TestSchemaValidator(BaseTestCase):
         specs = deepcopy(self.basespecs['iris'])
         index_col = "Species"
         specs['index_col'] = index_col
+        del specs['column_rules']['Species']
         validator = SchemaValidator(specification=specs)
         parser_args = validator.get_parser_args()
         self.assertItemsEqual(parser_args['index_col'], index_col)


### PR DESCRIPTION
If indexes have any constraints, they are treated at regular columns, and set back as the index only at the end of the cleaning stage.
