### PR TITLE
Change colnames utility to infer parsers for non-CSV files.

### DIFF
--- a/pysemantic/tests/test_utils.py
+++ b/pysemantic/tests/test_utils.py
@@ -27,6 +27,28 @@ class TestUtils(unittest.TestCase):
         actual = colnames(self.filepath)
         self.assertItemsEqual(actual, ideal)
 
+    def test_colnames_infer_parser_from_extension(self):
+        filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
+                           "person_activity.tsv")
+        ideal = "sequence_name tag date x y z activity".split()
+        actual = colnames(filepath)
+        self.assertItemsEqual(actual, ideal)
+
+    def test_colnames_parser_arg(self):
+        filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
+                           "person_activity.tsv")
+        ideal = "sequence_name tag date x y z activity".split()
+        from pandas import read_table
+        actual = colnames(filepath, parser=read_table)
+        self.assertItemsEqual(actual, ideal)
+
+    def test_colnames_infer_parser_from_sep(self):
+        filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
+                           "person_activity.tsv")
+        ideal = "sequence_name tag date x y z activity".split()
+        actual = colnames(filepath, sep='\\t')
+        self.assertItemsEqual(actual, ideal)
+
     def test_md5(self):
         ideal = "9b3ecf3031979169c0ecc5e03cfe20a6"
         actual = get_md5_checksum(self.filepath)

--- a/pysemantic/utils.py
+++ b/pysemantic/utils.py
@@ -68,7 +68,7 @@ def generate_questionnaire(filepath):
     return qdict
 
 
-def colnames(filename, **kwargs):
+def colnames(filename, parser=None, **kwargs):
     """
     Read the column names of a delimited file, without actually reading the
     whole file. This is simply a wrapper around `pandas.read_csv`, which reads
@@ -93,8 +93,18 @@ def colnames(filename, **kwargs):
         UserWarning("The nrows parameter is pointless here. This function only"
                     "reads one row.")
         kwargs.pop('nrows')
-    import pandas as pd
-    return pd.read_csv(filename, nrows=1, **kwargs).columns.tolist()
+    if parser is None:
+        if "sep" in kwargs:
+            sep = kwargs.get('sep')
+            if sep == r"\t":
+                parser = pd.read_table
+            else:
+                parser = pd.read_csv
+        elif filename.endswith('.csv'):
+            parser = pd.read_csv
+        elif filename.endswith('.tsv'):
+            parser = pd.read_table
+    return parser(filename, nrows=1, **kwargs).columns.tolist()
 
 
 def get_md5_checksum(filepath):

--- a/pysemantic/utils.py
+++ b/pysemantic/utils.py
@@ -100,10 +100,10 @@ def colnames(filename, parser=None, **kwargs):
                 parser = pd.read_table
             else:
                 parser = pd.read_csv
-        elif filename.endswith('.csv'):
-            parser = pd.read_csv
         elif filename.endswith('.tsv'):
             parser = pd.read_table
+        else:
+            parser = pd.read_csv
     return parser(filename, nrows=1, **kwargs).columns.tolist()
 
 


### PR DESCRIPTION
- Supply paser as argument
- Infer parser from delimiter specified
- Infer parser from filename extension
