### PR TITLE
Pop the sep argument when using pd.read_table

### DIFF
--- a/pysemantic/utils.py
+++ b/pysemantic/utils.py
@@ -88,7 +88,6 @@ def colnames(filename, parser=None, **kwargs):
     ['Sepal Length', 'Petal Length', 'Sepal Width', 'Petal Width', 'Species']
 
     """
-
     if 'nrows' in kwargs:
         UserWarning("The nrows parameter is pointless here. This function only"
                     "reads one row.")
@@ -98,6 +97,7 @@ def colnames(filename, parser=None, **kwargs):
             sep = kwargs.get('sep')
             if sep == r"\t":
                 parser = pd.read_table
+                kwargs.pop('sep')
             else:
                 parser = pd.read_csv
         elif filename.endswith('.tsv'):

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -78,6 +78,8 @@ class ParseErrorHandler(object):
                     self.parser = pd.read_csv
                 else:
                     self.parser = pd.read_table
+                    if sep == r'\\t':
+                        argdict.pop('sep', None)
             else:
                 self.parser = self._load_excel_sheet
 


### PR DESCRIPTION
The pandas.read_table parser assumes the separator to be a tab, no need
to provide it in calls to read_table
