### PR TITLE
Fix filepath traits

### DIFF
--- a/pysemantic/custom_traits.py
+++ b/pysemantic/custom_traits.py
@@ -10,7 +10,7 @@
 
 import os.path as op
 
-from traits.api import File, List
+from traits.api import File, List, TraitError
 
 
 class ValidTraitList(List):
@@ -32,9 +32,13 @@ class AbsFile(File):
     file.
     """
 
+    exists = True
+
     def validate(self, obj, name, value):
         validated_value = super(AbsFile, self).validate(obj, name, value)
         if validated_value and op.isabs(validated_value) and op.isfile(value):
             return validated_value
+        elif not op.isfile(value):
+            raise TraitError("The filepath does not exist.")
 
         self.error(obj, name, value)

--- a/pysemantic/tests/test_custom_traits.py
+++ b/pysemantic/tests/test_custom_traits.py
@@ -55,6 +55,12 @@ class TestCustomTraits(unittest.TestCase):
                           op.basename(__file__))
         self.assertRaises(TraitError, self.setter, "filelist", "/foo/bar")
 
+    def test_absolute_filepath_nonexistent(self):
+        """Test if the Absfile trait raises the correct error when the filepath
+        is absolute but doesn't exist."""
+        self.assertRaisesRegexp(TraitError, 'The filepath does not exist.',
+                                self.setter, "filepath", '/foo/bar')
+
     def test_absolute_path_file_trait(self):
         """Test if the `traits.AbsFile` trait works correctly."""
         self.traits.filepath = op.abspath(__file__)


### PR DESCRIPTION
Filepaths that are absolute but don't exist were raising the wrong error. The
error message should point out that the file doesn't exist.
