### PR TITLE
Fix dropping of NaNs from cols where min/max rules are specified

### DIFF
--- a/docs/schema_ref.rst
+++ b/docs/schema_ref.rst
@@ -304,8 +304,8 @@ The following parameters can be supplied to any column under ``column_rules``:
 * ``is_drop_duplicates`` ([true|false], default false) Setting this to ``true`` causes PySemantic to drop all duplicated values in the column.
 * ``unique_values``: These are the unique values that are expected in a column. The value of this parameter has to be a yaml list. Any value not found in this list will be dropped when cleaning the dataset.
 * ``exclude``: These are the values that are to be explicitly excluded from the column. This comes in handy when a column has too many unique values, and a handful of them have to be dropped. Note that this value has to be a list.
-* ``minimum``: Minimum value allowed in a column if the column holds numerical data. By default, the minimum is -np.inf. Any value less than this one is dropped.
-* ``maximum``: Maximum value allowed in a column if the column holds numerical data. By default, the maximum is np.inf. Any value greater than this one is dropped.
+* ``min``: Minimum value allowed in a column if the column holds numerical data. By default, the minimum is -np.inf. Any value less than this one is dropped.
+* ``max``: Maximum value allowed in a column if the column holds numerical data. By default, the maximum is np.inf. Any value greater than this one is dropped.
 * ``regex``: A regular expression that each element of the column must match, if the column holds text data. Any element of the column not matching this regex is dropped.
 * ``na_values``: A list of values that are considered as NAs by the pandas parsers, applicable to this column.
 * ``postprocessors``: A list of callables that called one by one on the columns. Any python function that accepts a series, and returns a series can be a postprocessor.
@@ -321,9 +321,9 @@ Here is a more extensive example of the usage of this schema.
       Sepal Width: !!python/name:numpy.floor
     column_rules:
       Sepal Length:
-        minimum: 2.0
+        min: 2.0
       Petal Length:
-        maximum: 4.0
+        max: 4.0
       Petal Width:
         exclude:
           - 3.14

--- a/pysemantic/tests/test_utils.py
+++ b/pysemantic/tests/test_utils.py
@@ -22,12 +22,15 @@ class TestUtils(unittest.TestCase):
                                 "iris.csv")
 
     def test_colnames(self):
+        """Test if the column names are read correctly from a file."""
         ideal = ['Sepal Length', 'Sepal Width', 'Petal Length', 'Petal Width',
                  'Species']
         actual = colnames(self.filepath)
         self.assertItemsEqual(actual, ideal)
 
     def test_colnames_infer_parser_from_extension(self):
+        """Test if the colnames function can infer the correct parser from the
+        file extension."""
         filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
                            "person_activity.tsv")
         ideal = "sequence_name tag date x y z activity".split()
@@ -35,6 +38,7 @@ class TestUtils(unittest.TestCase):
         self.assertItemsEqual(actual, ideal)
 
     def test_colnames_parser_arg(self):
+        """Test if the colnames are read if the parser is specified."""
         filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
                            "person_activity.tsv")
         ideal = "sequence_name tag date x y z activity".split()
@@ -43,6 +47,7 @@ class TestUtils(unittest.TestCase):
         self.assertItemsEqual(actual, ideal)
 
     def test_colnames_infer_parser_from_sep(self):
+        """Test if the colnames are read if the separator is specified."""
         filepath = op.join(op.abspath(op.dirname(__file__)), "testdata",
                            "person_activity.tsv")
         ideal = "sequence_name tag date x y z activity".split()
@@ -50,6 +55,7 @@ class TestUtils(unittest.TestCase):
         self.assertItemsEqual(actual, ideal)
 
     def test_md5(self):
+        """Test the md5 checksum calculator."""
         ideal = "9b3ecf3031979169c0ecc5e03cfe20a6"
         actual = get_md5_checksum(self.filepath)
         self.assertEqual(ideal, actual)

--- a/pysemantic/validator.py
+++ b/pysemantic/validator.py
@@ -390,15 +390,6 @@ class DataFrameValidator(HasTraits):
             ix = self.nrows(self.data.index)
             self.data = self.data.ix[self.data.index[ix]]
 
-        if self.is_drop_na:
-            x = self.data.shape[0]
-            try:
-                self.data.dropna(inplace=True)
-            except TypeError:
-                print "Cannot drop na."
-            y = self.data.shape[0]
-            logger.info("{0} rows containing NAs were dropped.".format(x - y))
-
         if self.is_drop_duplicates:
             x = self.data.shape[0]
             try:
@@ -423,6 +414,15 @@ class DataFrameValidator(HasTraits):
                 logger.info(json.dumps(validator.exclude_values))
                 # self.data.dropna(inplace=True)
         self.rename_columns()
+
+        if self.is_drop_na:
+            x = self.data.shape[0]
+            try:
+                self.data.dropna(inplace=True)
+            except TypeError:
+                print "Cannot drop na."
+            y = self.data.shape[0]
+            logger.info("{0} rows containing NAs were dropped.".format(x - y))
 
         if self.index_col:
             self.data.set_index(self.index_col, drop=True, inplace=True)


### PR DESCRIPTION
It wasn't possible to drop NaNs from columns where minmax rules were specified. See #77